### PR TITLE
chore: dont use bundle option in esbuild

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,12 +2,13 @@ import { build } from 'esbuild';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
+import { globSync } from 'node:fs';
 
 build({
-  entryPoints: ['lib/cli.ts', 'lib/main.ts'],
+  entryPoints: globSync('lib/**/*.ts', {
+    exclude: (f) => f.endsWith('.d.ts') || f.endsWith('.test.ts'),
+  }),
   outdir: 'dist',
-  bundle: true,
-  external: ['chalk', 'cac', 'typescript'],
   target: 'node18',
   platform: 'node',
   format: 'esm',

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "rm -rf dist && node ./build.js",
     "type-check": "tsc -b",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && tsx ./test.js",
+    "test": "tsx ./test.js",
     "tsr": "npm run build && node dist/cli.js -p tsconfig.lib.json 'lib/[a-z]+\\.ts'"
   },
   "devDependencies": {


### PR DESCRIPTION
using `bundle: true` meant that we were publishing same parts of the code in the two bundles cli.js and main.js.
This PR will change esbuild's settings to not create bundles for publishing