### PR TITLE
fix: prevent removing decorators on classes

### DIFF
--- a/lib/util/edit.test.ts
+++ b/lib/util/edit.test.ts
@@ -289,6 +289,65 @@ function a2() {}`,
   });
 
   describe('class declaration', () => {
+    it('should not remove decorators when exports are deleted', () => {
+      const fileService = new MemoryFileService();
+
+      fileService.set('/app/main.ts', ``);
+      fileService.set(
+        '/app/a.ts',
+        `@myDecorator
+export class A {}
+const a = new A();
+console.log(a);`,
+      );
+      fileService.set(
+        '/app/b.ts',
+        `@myDecorator
+export default class B {}
+const b = new B();
+console.log(b);`,
+      );
+      fileService.set(
+        '/app/c.ts',
+        `@firstDecorator
+@secondDecorator(() => [WithArgument])
+export default class C {}
+const c = new C();
+console.log(c);`,
+      );
+
+      edit({
+        fileService,
+        recursive,
+        entrypoints: ['/app/main.ts'],
+      });
+
+      assert.equal(
+        fileService.get('/app/a.ts'),
+        `@myDecorator
+class A {}
+const a = new A();
+console.log(a);`,
+      );
+
+      assert.equal(
+        fileService.get('/app/b.ts'),
+        `@myDecorator
+class B {}
+const b = new B();
+console.log(b);`,
+      );
+
+      assert.equal(
+        fileService.get('/app/c.ts'),
+        `@firstDecorator
+@secondDecorator(() => [WithArgument])
+class C {}
+const c = new C();
+console.log(c);`,
+      );
+    });
+
     it('should not remove export for class if its used in some other file', () => {
       const fileService = new MemoryFileService();
 


### PR DESCRIPTION
Prevents removing decorators on exported classes that won't be exported anymore

# Case

```
@firstDecorator
@secondDecorator(() => [WithArgument])
export default class C {}
const c = new C();
console.log(c);
```

# Before

```
class C {}
const c = new C();
console.log(c);
```

# After

```
@firstDecorator
@secondDecorator(() => [WithArgument])
class C {}
const c = new C();
console.log(c);
```