### PR TITLE
fix: prevent deleting files importes for side-effect

### DIFF
--- a/lib/util/edit.test.ts
+++ b/lib/util/edit.test.ts
@@ -2103,4 +2103,22 @@ export const a = 'a';`,
       );
     });
   });
+
+  describe('side effect import', () => {
+    it('should not remove file if it is used for side effects', () => {
+      const fileService = new MemoryFileService();
+      fileService.set('/app/main.ts', `import './a';`);
+      fileService.set('/app/a.ts', `console.log('a');`);
+
+      edit({
+        fileService,
+        recursive,
+        deleteUnusedFile: true,
+        entrypoints: ['/app/main.ts'],
+      });
+
+      assert.equal(fileService.get('/app/main.ts'), `import './a';`);
+      assert.equal(fileService.get('/app/a.ts'), `console.log('a');`);
+    });
+  });
 });

--- a/lib/util/findFileUsage.test.ts
+++ b/lib/util/findFileUsage.test.ts
@@ -156,4 +156,25 @@ describe('findFileUsage', () => {
     // but for now this is the expected behavior
     assert.deepEqual(result, new Set(['glob', 'cwd']));
   });
+
+  it('should handle files imported only for side effects', () => {
+    const fileService = new MemoryFileService();
+    fileService.set('/app/main.ts', `import './a';`);
+    fileService.set('/app/a.ts', `console.log('a');`);
+
+    const graph = createDependencyGraph({
+      fileService,
+      options,
+      entrypoints: ['/app/main.ts'],
+    });
+    const result = findFileUsage({
+      targetFile: '/app/a.ts',
+      vertexes: graph.eject(),
+      files: fileService.eject(),
+      fileNames: fileService.getFileNames(),
+      options: {},
+    });
+
+    assert.deepEqual(result, new Set(['#side-effect']));
+  });
 });

--- a/lib/util/findFileUsage.ts
+++ b/lib/util/findFileUsage.ts
@@ -133,6 +133,9 @@ export const findFileUsage = ({
   }
 
   return new Set(
-    result.filter((it) => exportsOfTargetFile.has(it) || it === '*'),
+    result.filter(
+      (it) =>
+        exportsOfTargetFile.has(it) || it === '*' || it === '#side-effect',
+    ),
   );
 };

--- a/lib/util/parseFile.ts
+++ b/lib/util/parseFile.ts
@@ -605,6 +605,13 @@ const fn = ({
         imports[resolved]?.push('default');
       }
 
+      // side effect import
+      if (!node.importClause) {
+        imports[resolved] ||= [];
+        // using a special symbol that can't be a valid identifier
+        imports[resolved]?.push('#side-effect');
+      }
+
       return;
     }
 


### PR DESCRIPTION
A file that is used only for side-effects would be deleted. Now it's not the case.