### PR TITLE
fix: unable to use js-api due to incorrect type exports

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,3 +1,1 @@
-export { tsr, Config } from './tsr.js';
-export { Logger } from './util/Logger.js';
-export * from './util/error.js';
+export { tsr } from './tsr.js';

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -6,6 +6,7 @@
     "lib": ["ES2023"],
     "target": "ES2022",
     "strict": true,
+    "emitDeclarationOnly": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
when using the JS api, tsr throws an error due to incorrect exports of types as described here: #117 